### PR TITLE
Don't export SDS API and don't install sds header file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ install:all
 	install -D libcetcd.so $(prefix)/lib/libcetcd.so
 	install -D cetcd.h $(prefix)/include/cetcd.h
 	install -D cetcd_array.h $(prefix)/include/cetcd_array.h
-	install -D sds/sds.h $(prefix)/include/sds/sds.h
 
 libcetcd.so: cetcd_array.o sds/sds.o cetcd.o
 	$(CC) $(LDFLAGS) -shared -o libcetcd.so cetcd_array.o sds/sds.o cetcd.o third-party/build/*.o

--- a/cetcd.c
+++ b/cetcd.c
@@ -1,4 +1,6 @@
 #include "cetcd.h"
+#include "sds/sds.h"
+typedef sds cetcd_string;
 #include "cetcd_json_parser.h"
 
 #include <string.h>

--- a/cetcd.h
+++ b/cetcd.h
@@ -8,10 +8,8 @@ extern "C" {
 #include <curl/curl.h>
 #include <pthread.h>
 #include <stdint.h>
-#include "sds/sds.h"
 #include "cetcd_array.h"
 #define CETCD_VERSION release-v0.0.5
-typedef sds cetcd_string;
 typedef pthread_t cetcd_watch_id;
 
 enum HTTP_METHOD {


### PR DESCRIPTION
SDS is used by cetcd only internal, not by the public API.
We should not expose the SDS API, else other projects using
SDS could get a problem.